### PR TITLE
Usability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CALDERA Plugin: Builder
 
-The Builder plugin enables Caldera to dynamically compile code segments into payloads that can be executed as abilities 
+The Builder plugin enables CALDERA to dynamically compile code segments into payloads that can be executed as abilities 
 by implants.
 
 ### Installation:
@@ -13,3 +13,41 @@ sudo ./install.sh
 ### Dependencies/Requirements:
 1. Docker
 2. docker-py
+
+### Sample Ability
+
+The following ability will compile the HelloWorld.exe executable, copy it to the machine running the agent, and execute
+it using either cmd or PowerShell.
+
+```yaml
+---
+
+- id: 096a4e60-e761-4c16-891a-3dc4eff02e74
+  name: C# Hello World
+  description: Dynamically compile HelloWorld.exe
+  tactic: execution
+  technique:
+    attack_id: T1059
+    name: Command-Line Interface
+  platforms:
+    windows:
+      psh,cmd:
+        build_target: HelloWorld.exe
+        language: csharp
+        code: |
+          using System;
+
+          namespace HelloWorld
+          {
+              class Program
+              {
+                  static void Main(string[] args)
+                  {
+                      Console.WriteLine("Hello World!");
+                  }
+              }
+          }
+```
+
+DLL dependencies can be added by declaring a `payloads` list at the root of the ability.
+

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -143,6 +143,7 @@ class BuildService(BaseService):
         container = self.docker_client.containers.run(image=self.build_envs[ability.language].short_id, remove=True,
                                                       command='{} {}'.format(env['entrypoint'], args).split(' '),
                                                       working_dir=env['workdir'],
+                                                      user=os.getuid(),
                                                       volumes={os.path.abspath(
                                                                os.path.join(self.build_directory, ability.language)):
                                                                dict(bind=env['workdir'], mode='rw')}, detach=True)

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -94,6 +94,9 @@ class BuildService(BaseService):
     def _stage_payload(self, language, payload):
         """Move Docker-built payload to CALDERA payload directory
 
+        Adds special rules:
+        - Appends .exe to .donut files.
+
         :param language: Language the payload was built for
         :param language: string
         :param payload: Payload name
@@ -101,6 +104,8 @@ class BuildService(BaseService):
         """
         src = os.path.join(self.build_directory, language, payload)
         dst = os.path.join(self.payloads_directory, payload)
+        if dst.endswith('.donut'):
+            dst = '{}.exe'.format(dst)
         if os.path.isfile(dst):
             os.remove(dst)
         if os.path.exists(src):

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -44,7 +44,7 @@ class BuildService(BaseService):
 
     @staticmethod
     def _build_command_block_syntax(payload):
-        return '%s' % payload
+        return '.\\%s' % payload
 
     async def _download_docker_images(self):
         for k, v in self.get_config(prop='enabled', name='build').items():

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -31,11 +31,13 @@ class BuildService(BaseService):
         :param ability: Ability to set command and payloads for
         :type ability: Ability
         """
-        if not ability.test:
-            command, payload = await self._dynamically_compile_ability_code(ability=ability)
-            ability.test = command
-            if payload not in ability.payloads:
-                ability.payloads.append(payload)
+        if not ability.additional_info.get('built'):
+            await self._dynamically_compile_ability_code(ability=ability)
+
+            if not ability.test:
+                ability.test = self._build_command_block_syntax(payload=ability.build_target)
+            if ability.build_target not in ability.payloads:
+                ability.payloads.append(ability.build_target)
 
     async def stage_enabled_dockers(self):
         """Start downloading docker images"""
@@ -56,7 +58,7 @@ class BuildService(BaseService):
         self._check_errors(language=ability.language)
         self._stage_payload(language=ability.language, payload=ability.build_target)
         self._purge_build_directory(language=ability.language)
-        return self._build_command_block_syntax(payload=ability.build_target), ability.build_target
+        ability.additional_info['built'] = True
 
     @staticmethod
     def _build_command_block_syntax(payload):

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -20,11 +20,17 @@ class BuildService(BaseService):
         self.build_file = 'code'
 
     async def initialize_code_hook_functions(self):
+        """Start dynamic code compilation for abilities"""
         for ab in await self.data_svc.locate('abilities'):
             if ab.code:
                 ab.HOOKS[ab.language] = self.generate_ability_execution_method
 
     async def generate_ability_execution_method(self, ability):
+        """Set command and payloads for an Ability
+
+        :param ability: Ability to set command and payloads for
+        :type ability: Ability
+        """
         if not ability.test:
             command, payload = await self._dynamically_compile_ability_code(ability=ability)
             ability.test = command
@@ -32,37 +38,65 @@ class BuildService(BaseService):
                 ability.payloads.append(payload)
 
     async def stage_enabled_dockers(self):
+        """Start downloading docker images"""
         await self._download_docker_images()
 
     """ PRIVATE """
 
     async def _dynamically_compile_ability_code(self, ability):
-        await self._stage_code_in_docker_folder(ability)
+        """Dynamically compile code for an Ability
+
+        :param ability: Ability to dynamically compile code for
+        :type ability: Ability
+        :return: Command to run, payload name
+        :rtype: string, string
+        """
+        await self._stage_docker_directory(ability)
         self._run_target_docker(ability=ability, args=self._replace_args_props(ability=ability))
         self._check_errors(language=ability.language)
         self._stage_payload(language=ability.language, payload=ability.build_target)
-        self._purge_build_folder(language=ability.language)
+        self._purge_build_directory(language=ability.language)
         return self._build_command_block_syntax(payload=ability.build_target), ability.build_target
 
     @staticmethod
     def _build_command_block_syntax(payload):
+        """Creates the command to run for a given payload
+
+        :param payload: Payload name
+        :type payload: string
+        :return: Agent command to run
+        :rtype: string
+        """
         return '.\\%s' % payload
 
     async def _download_docker_images(self):
-        for k, v in self.get_config(prop='enabled', name='build').items():
-            await self._stage_build_dir(directory=k)
-            data = self.docker_client.images.list(name=v['docker'])
+        """Download required docker images"""
+        for language, language_data in self.get_config(prop='enabled', name='build').items():
+            await self._stage_build_dir(language=language)
+            data = self.docker_client.images.list(name=language_data['docker'])
             if not data:
-                data = self.docker_client.images.pull(v['docker'])
-            self.build_envs[k] = data[0] if isinstance(data, list) else data
+                data = self.docker_client.images.pull(language_data['docker'])
+            self.build_envs[language] = data[0] if isinstance(data, list) else data
 
-    async def _stage_build_dir(self, directory):
+    async def _stage_build_dir(self, language):
+        """Create a build directory for a particular language
+
+        :param language: Language to create directory for
+        :type language: string
+        """
         try:
-            os.mkdir(os.path.join(self.build_directory, directory))
+            os.mkdir(os.path.join(self.build_directory, language))
         except FileExistsError:
-            self.log.debug('Build directory for %s already constructed' % directory)
+            self.log.debug('Build directory for %s already constructed' % language)
 
     def _stage_payload(self, language, payload):
+        """Move Docker-built payload to CALDERA payload directory
+
+        :param language: Language the payload was built for
+        :param language: string
+        :param payload: Payload name
+        :param payload: string
+        """
         src = os.path.join(self.build_directory, language, payload)
         dst = os.path.join(self.payloads_directory, payload)
         if os.path.isfile(dst):
@@ -70,7 +104,12 @@ class BuildService(BaseService):
         if os.path.exists(src):
             shutil.move(src=src, dst=dst)
 
-    async def _stage_code_in_docker_folder(self, ability):
+    async def _stage_docker_directory(self, ability):
+        """Create code file and DLL references in Docker build directory
+
+        :param ability: Ability to be built
+        :type ability: Ability
+        """
         if ability.code:
             with open(os.path.join(self.build_directory, ability.language, self.build_file), 'w') as f:
                 f.write(self.decode_bytes(ability.code))
@@ -83,11 +122,23 @@ class BuildService(BaseService):
             dst = os.path.join(self.build_directory, ability.language)
             shutil.copy(src=src, dst=dst)
 
-    def _purge_build_folder(self, language):
+    def _purge_build_directory(self, language):
+        """Remove all files from language build directory
+
+        :param language: Language to clear build directory for
+        :type language: string
+        """
         for f in glob.iglob(f'{self.build_directory}/{language}/*'):
             os.remove(f)
 
     def _run_target_docker(self, ability, args):
+        """Run docker container to build ability files
+
+        :param ability: Ability to build code for
+        :type ability: Ability
+        :param args: Arguments to pass to the entrypoint command
+        :type args: string
+        """
         env = self.get_config(prop='enabled', name='build').get(ability.language)
         container = self.docker_client.containers.run(image=self.build_envs[ability.language].short_id, remove=True,
                                                       command=('%s %s' % (env['entrypoint'], args)).split(' '),
@@ -99,24 +150,37 @@ class BuildService(BaseService):
         self.log.debug('Container for %s ran for ability ID %s: %s' % (ability.language, ability.ability_id, code))
 
     def _check_errors(self, language):
-        error_log = os.path.join(self.build_directory, language, 'error.log')
-        if os.path.isfile(error_log):
-            with open(error_log) as f:
-                log_data = json.load(f)
+        """Check for errors which occurred during the build
 
-            errors = log_data['runs'][0]['results']
-            for error in errors:
-                location_data = ''
-                if error.get('locations'):
-                    for location in error.get('locations'):
-                        region = location['resultFile']['region']
-                        location_data = '{}({},{},{},{}): '.format(location['resultFile']['uri'],
+        :param language: Language to check errors for
+        :type language: string
+        """
+        if language == 'csharp':
+            error_log = os.path.join(self.build_directory, language, 'error.log')
+            if os.path.isfile(error_log):
+                with open(error_log) as f:
+                    log_data = json.load(f)
+
+                errors = log_data['runs'][0]['results']
+                for error in errors:
+                    location_data = ''
+                    locations = error.get('locations', [])
+                    if locations:
+                        region = locations[0]['resultFile']['region']
+                        location_data = '{}({},{},{},{}): '.format(locations[0]['resultFile']['uri'],
                                                                    region.get('startLine'), region.get('startColumn'),
                                                                    region.get('endLine'), region.get('endColumn'))
-                self.log.debug('{}{} {}: {}'.format(location_data, error.get('level').capitalize(), error.get('ruleId'),
-                                                    error.get('message')))
+                    self.log.debug('{}{} {}: {}'.format(location_data, error.get('level').capitalize(),
+                                                        error.get('ruleId'), error.get('message')))
 
     def _replace_args_props(self, ability):
+        """Replace template arguments in build command
+
+        :param ability: Ability to create command for
+        :type ability: Ability
+        :return: Created command string
+        :rtype: string
+        """
         env = self.get_config(prop='enabled', name='build').get(ability.language)
         cmd = env['entrypoint_args'].replace('#{code}', self.build_file)
         cmd = cmd.replace('#{build_target}', ability.build_target)

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -63,9 +63,9 @@ class BuildService(BaseService):
     def _stage_payload(self, language, payload):
         src = os.path.join(self.build_directory, language, payload)
         dst = os.path.join(self.payloads_directory, payload)
+        if os.path.isfile(dst):
+            os.remove(dst)
         if os.path.exists(src):
-            if os.path.isfile(dst):
-                os.remove(dst)
             shutil.move(src=src, dst=dst)
 
     async def _stage_code_in_docker_folder(self, ability):

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -94,8 +94,7 @@ class BuildService(BaseService):
                                                                os.path.join(self.build_directory, ability.language)):
                                                                dict(bind=env['workdir'], mode='rw')}, detach=True)
         code = container.wait()
-        self.log.debug('Container for %s ran for ability ID %s: %s' % (ability.language, ability.ability_id,
-                                                                       code))
+        self.log.debug('Container for %s ran for ability ID %s: %s' % (ability.language, ability.ability_id, code))
 
     def _replace_args_props(self, ability):
         env = self.get_config(prop='enabled', name='build').get(ability.language)
@@ -103,6 +102,6 @@ class BuildService(BaseService):
         cmd = cmd.replace('#{build_target}', ability.build_target)
 
         references = [p for p in ability.payloads if p.endswith('.dll')]
-        reference_cmd = '/r:{}'.format(','.join(references)) if references else ''
-        cmd = cmd.replace('#{references}', reference_cmd)
+        reference_cmd = ' -r:{}'.format(','.join(references)) if references else ''
+        cmd = cmd.replace(' #{references}', reference_cmd)
         return cmd

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -1,8 +1,9 @@
-import docker
 import glob
 import os
 import shutil
 import json
+
+import docker
 
 from app.utility.base_service import BaseService
 

--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -67,7 +67,7 @@ class BuildService(BaseService):
         :return: Agent command to run
         :rtype: string
         """
-        return '.\\%s' % payload
+        return '.\\{}'.format(payload)
 
     async def _download_docker_images(self):
         """Download required docker images"""
@@ -87,7 +87,7 @@ class BuildService(BaseService):
         try:
             os.mkdir(os.path.join(self.build_directory, language))
         except FileExistsError:
-            self.log.debug('Build directory for %s already constructed' % language)
+            self.log.debug('Build directory for {} already constructed'.format(language))
 
     def _stage_payload(self, language, payload):
         """Move Docker-built payload to CALDERA payload directory
@@ -141,13 +141,13 @@ class BuildService(BaseService):
         """
         env = self.get_config(prop='enabled', name='build').get(ability.language)
         container = self.docker_client.containers.run(image=self.build_envs[ability.language].short_id, remove=True,
-                                                      command=('%s %s' % (env['entrypoint'], args)).split(' '),
+                                                      command='{} {}'.format(env['entrypoint'], args).split(' '),
                                                       working_dir=env['workdir'],
                                                       volumes={os.path.abspath(
                                                                os.path.join(self.build_directory, ability.language)):
                                                                dict(bind=env['workdir'], mode='rw')}, detach=True)
         code = container.wait()
-        self.log.debug('Container for %s ran for ability ID %s: %s' % (ability.language, ability.ability_id, code))
+        self.log.debug('Container for {} ran for ability ID {}: {}'.format(ability.language, ability.ability_id, code))
 
     def _check_errors(self, language):
         """Check for errors which occurred during the build

--- a/conf/environments.yml
+++ b/conf/environments.yml
@@ -4,4 +4,4 @@ enabled:
     workdir: /opt/build
     entrypoint: csc
     entrypoint_args: |
-      #{code} /out:#{build_target}
+      #{code} /out:#{build_target} #{references}

--- a/conf/environments.yml
+++ b/conf/environments.yml
@@ -5,3 +5,4 @@ enabled:
     entrypoint: csc
     entrypoint_args: |
       #{code} -out:#{build_target} #{references} -errorlog:error.log
+

--- a/conf/environments.yml
+++ b/conf/environments.yml
@@ -4,4 +4,4 @@ enabled:
     workdir: /opt/build
     entrypoint: csc
     entrypoint_args: |
-      #{code} /out:#{build_target} #{references}
+      #{code} -out:#{build_target} #{references} -errorlog:error.log


### PR DESCRIPTION
* Added support for DLL dependencies: adds reference during compile time and copies DLL alongside EXE to the agent.
* Remove old payloads: even if a build errors, remove the previously-compiled payload if it exists. Useful during development if a build errors.
* Added error log parsing: csc creates an error log during build, all errors are written to the log. Execution is not stopped, but the EXE shouldn't be copied to the host, so the ability will give an error that the executable doesn't exist.
* Added sample ability