### PR TITLE
Don't strip newlines in source code

### DIFF
--- a/app/build_svc.py
+++ b/app/build_svc.py
@@ -120,7 +120,7 @@ class BuildService(BaseService):
         """
         if ability.code:
             with open(os.path.join(self.build_directory, ability.language, self.build_file), 'w') as f:
-                f.write(self.decode_bytes(ability.code))
+                f.write(self.decode_bytes(ability.code, strip_newlines=False))
 
         for payload in [p for p in ability.payloads if p.endswith('.dll')]:
             payload_name = payload


### PR DESCRIPTION
Source code doesn't need to be stripped for newlines the same way inline PowerShell or Bash would. Without newlines, error messages all point to column numbers on line 1. With newlines, code can be more easily debugged.

Requires https://github.com/mitre/caldera/pull/1949.