### PR TITLE
Don't use cgo for linux builds

### DIFF
--- a/conf/environments.yml
+++ b/conf/environments.yml
@@ -40,4 +40,4 @@ enabled:
     extension: go
     workdir: /go/src
     build_command: |
-      /bin/bash -c "#{modules} GOOS=linux GOARCH=amd64 GOCACHE=/go/src/.cache go build -o #{build_target} > error.log 2>&1"
+      /bin/bash -c "#{modules} GOOS=linux GOARCH=amd64 GOCACHE=/go/src/.cache CGO_ENABLED=0 go build -o #{build_target} > error.log 2>&1"


### PR DESCRIPTION
## Description

Using cgo may result in dependency issues on certain hosts.

Builds with certain packages, such as `net`, usually have some dynamic linking to libc. We build the binary in a container with these libraries, but we want to be able to run this binary everywhere. cgo is not enabled for cross-compiling, which is how we should be treating linux to linux.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Building with cgo did not work in a stripped-down container.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
