### PR TITLE
Disable GO111MODULE by default

### DIFF
--- a/conf/environments.yml
+++ b/conf/environments.yml
@@ -34,10 +34,10 @@ enabled:
     extension: go
     workdir: /go/src
     build_command: |
-      /bin/bash -c "#{modules} GOOS=windows GOARCH=amd64 GOCACHE=/go/src/.cache go build -o #{build_target} > error.log 2>&1"
+      /bin/bash -c "#{modules} GOOS=windows GOARCH=amd64 GOCACHE=/go/src/.cache GO111MODULE=off go build -o #{build_target} > error.log 2>&1"
   go_linux:
     docker: golang:latest
     extension: go
     workdir: /go/src
     build_command: |
-      /bin/bash -c "#{modules} GOOS=linux GOARCH=amd64 GOCACHE=/go/src/.cache CGO_ENABLED=0 go build -o #{build_target} > error.log 2>&1"
+      /bin/bash -c "#{modules} GOOS=linux GOARCH=amd64 GOCACHE=/go/src/.cache GO111MODULE=off CGO_ENABLED=0 go build -o #{build_target} > error.log 2>&1"


### PR DESCRIPTION
## Description

The following error may show up in the latest version of Go (1.16):

```
 go: go.mod file not found in current directory or any parent directory; see 'go help modules'
```

Builder is using `GOPATH` instead of `GO111MODULE`. The docker container used now downloads Go 1.16, which sets `GO111MODULE=on`  by default, breaking the building of go payloads. Explicitly setting this off fixes the issue and maintains backwards compatibility.

More information: [Why is GO111MODULE everywhere, and everything about Go Modules (updated with Go 1.16)
](https://maelvls.dev/go111module-everywhere/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with Go 1.15 and 1.16. A Go builder ability is required.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
