### PR TITLE
Update environments.yml to limit image pulls to latest dockercross version

### DIFF
--- a/conf/environments.yml
+++ b/conf/environments.yml
@@ -6,25 +6,25 @@ enabled:
     build_command: |
       csc #{code} -out:#{build_target} #{references} -errorlog:error.log
   cpp_windows_x64:
-    docker: dockcross/windows-static-x64
+    docker: dockcross/windows-static-x64:latest
     extension: cpp
     workdir: /opt/build
     build_command: |
       /bin/bash -c "$CXX -x c++ -o #{build_target} #{code} > error.log 2>&1"
   cpp_windows_x86:
-    docker: dockcross/windows-static-x86
+    docker: dockcross/windows-static-x86:latest
     extension: cpp
     workdir: /opt/build
     build_command: |
       /bin/bash -c "$CXX -x c++ -o #{build_target} #{code} > error.log 2>&1"
   c_windows_x64:
-    docker: dockcross/windows-static-x64
+    docker: dockcross/windows-static-x64:latest
     extension: c
     workdir: /opt/build
     build_command: |
       /bin/bash -c "$CC -x c -o #{build_target} #{code} > error.log 2>&1"
   c_windows_x86:
-    docker: dockcross/windows-static-x86
+    docker: dockcross/windows-static-x86:latest
     extension: c
     workdir: /opt/build
     build_command: |


### PR DESCRIPTION
Without the tag of latest all images matching the name are being pulled down

## Description

All dockcross image variations for windows-static-x64 were being pulled down during the launch of the Caldera.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I've added the "latest" tag to the dockcross images and it limited to just the latest images vs. the 500Gb plus of images it was pulling previously.


## Checklist:

- [X] I have performed a self-review of my own code

