### PR TITLE
Update install.sh to function again with Kali

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,16 @@ function ubuntu_install_docker() {
     exec sudo su -l $USER
 }
 
+function kali_install_docker() {
+    install_wrapper "Remove existing docker stubs" "apt-get remove -y docker docker-engine docker.io containerd runc" $WARNING
+    install_wrapper "Install pre-requisites" "apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common" $WARNING
+    install_wrapper "Add docker GPG key" "curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --batch --yes --dearmor -o /etc/apt/trusted.gpg.d/docker-ce-archive-keyring.gpg" $WARNING
+    install_wrapper "Add docker repository" "add-apt-repository 'deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable' -y" $WARNING
+    install_wrapper "Install docker" "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io" $WARNING
+    install_wrapper "Add user to docker group" "usermod $USER -a -G docker" $CRITICAL
+    exec sudo su -l $USER
+}
+
 function darwin() {
     [[ $EUID -ne 0 ]] && echo "You must run the script with sudo." && exit 1
     echo "[X] Not implemented at this time..."1
@@ -61,7 +71,7 @@ function kali() {
     [[ $EUID -ne 0 ]] && echo "You must run the script with sudo." && exit 1
     echo "[-] Installing on Kali (Debian)..."
     initialize_log
-    ubuntu_install_docker
+    kali_install_docker
 }
 
 function centos() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-docker
+docker~=6.1.0


### PR DESCRIPTION
## Description

2 bug fixes were applied:

1. Require docker-py to be 6.1.x to avoid an error with urllib3 (see: https://github.com/docker/docker-py/issues/3113) that prevented Caldera from enabling the builder plugin
2. Tweak `install.sh` such that the install for Kali distros works.

Will resolve https://github.com/mitre/caldera/issues/2793

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have tested the pip install and install.sh on Kali 2023.1 (kali-rolling).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
