### PR TITLE
Fix - Plugin start

### DIFF
--- a/gui/views/builder.vue
+++ b/gui/views/builder.vue
@@ -17,7 +17,7 @@ onMounted(async () => {
 <template lang="pug">
 .content    
   h2 Builder
-  p Dynamically compile ability code via docker containershr
+  p Dynamically compile ability code via docker containers.
 
 .content
 <!-- a table with a list of envs -->

--- a/gui/views/builder.vue
+++ b/gui/views/builder.vue
@@ -1,12 +1,13 @@
 <script setup>
-import { onMounted, ref } from "vue";
+import { ref, inject, onMounted } from "vue";
 const $api = inject("$api");
 
 const envs = ref();
 
 onMounted(async () => {
   try {
-    envs = await $api.get("/plugin/builder/environment");
+    const res = await $api.get("/plugin/builder/environment");
+    envs.value = res.data;
   } catch (error) {
     console.error(error);
   }

--- a/gui/views/builder.vue
+++ b/gui/views/builder.vue
@@ -25,11 +25,17 @@ onMounted(async () => {
     thead
       tr
         th Name
-        th Description
-        th
+        th Docker image
+        th File extension
+        th Working directory
+        th Build command
     tbody
-      tr(v-for="env in envs")
-        td {{ env }}
+      tr(v-for="(env, name) in envs" :key="name")
+        td {{ name }}
+        td {{ env.docker }}
+        td {{ env.extension }}
+        td {{ env.workdir }}
+        td {{ env.build_command }}
 .is-flex.is-align-items-center.is-justify-content-center
     a.button.is-primary(href="/docs/Dynamically-Compiled-Payloads.html" target="_blank")
         span Read more about using Builder to create dynamically-compiled payloads here:


### PR DESCRIPTION
## Description

Fixes:

* Crash when compiling `gui/views/builder.vue`,
* Invalid display of environment table,
* Typo in the main view description.

Preview of the new builder main view:

<img width="768" alt="image" src="https://github.com/mitre/builder/assets/10807538/868a0411-57a2-4fd2-938c-a1978d02c29b">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally.
Just starting Caldera with the builder `plugin` activated.
Note: To avoid pulling all Docker images (or if you don't have Docker installed), just comment the following lines in `hook.py`:

```python
async def enable(services):
    # [...]
    # build_svc = BuildService(services)
    # await build_svc.stage_enabled_dockers()
    # [...]
```


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
